### PR TITLE
Elaborate more on ME DTC implementation + fixing spelling of CMDS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,7 +60,7 @@
         "catppuccin",
         "CCIP",
         "CCRP",
-        "CDMS",
+        "CMDS",
         "CDNU",
         "centerpoints",
         "CHAL",

--- a/src/f14bu/dcs/mission_editor.md
+++ b/src/f14bu/dcs/mission_editor.md
@@ -49,18 +49,25 @@ option overrides the livery refueling probe cover option.
 
 ## DTC
 
+The F-14B Upgrade has its Mission Data Loader integrated into DCS' Mission
+Editor using the DTC menu. Refer to the
+[Mission Data Loader section](../systems/mdl/mission_data_loader.md) on more
+in-depth how to use MDL with the DTC menu.
+
 ### Navigation
 
-> 🚧 Work in Progress
-
 ![DTC Navigation Page](../../img/dtc_navigation_page.jpg)
+
+Refer to the
+[Flight Plan subsection](../systems/mdl/mission_data_loader.md#flight-plan) of
+the MDL section for more information.
 
 ### JDAM
 
 ![DTC JDAM Page](../../img/dtc_jdam_page.jpg)
 
 See the
-[Pre-Planned JDAM Employment section](..//weapons/air_to_ground/gps_guided_weapons/ggw_employment.md#pre-planned-jdam-employment)
+[Pre-Planned JDAM Employment section](../weapons/air_to_ground/gps_guided_weapons/ggw_employment.md#pre-planned-jdam-employment)
 for further information on programming the JDAMs using the DTC menu.
 
 ### CMDS
@@ -80,6 +87,9 @@ Refer to the
 page for my information on how to use the Tactical Imaging Set.
 
 #### Ownship Callsign
+
+Callsign for ownship can be changed here. By default, "Use mission callsign", is
+checked which means the DCS unit name (pilot) set in the mission editor is used.
 
 #### Send-To Callsigns
 

--- a/src/f14bu/systems/mdl/mission_data_loader.md
+++ b/src/f14bu/systems/mdl/mission_data_loader.md
@@ -217,9 +217,9 @@ For an in depth discussion of plot lines refer to the
 The JDAM Planning Tool section is found in the
 [GGW Pre Planned Employment Section](../../../f14bu/weapons/air_to_ground/gps_guided_weapons/ggw_employment.md#pre-planned-jdam-employment).
 
-## ALE-47 Counter Measure Dispensing system (CDMS) programming
+## ALE-47 Counter Measure Dispensing system (CMDS) programming
 
-The CDMS programmer is found in the
+The CMDS programmer is found in the
 [ALE-47 Section](../../../f14bu/systems/defensive_systems/countermeasures/ale_47.md#programmer).
 
 ## Tactical Imaging System

--- a/src/f14bu/systems/mdl/overview.md
+++ b/src/f14bu/systems/mdl/overview.md
@@ -12,5 +12,5 @@
 |   6.    | [Waypoint Designation](../mdl/mission_data_loader.md#waypoint-display-priority)                                                           |
 |   7.    | [Plot Line Designation](../mdl/mission_data_loader.md#plot-lines)                                                                         |
 |   8.    | [JDAM Planning Tool](../mdl/mission_data_loader.md#jdam-planning-tool)                                                                    |
-|   9.    | [CDMS](../mdl/mission_data_loader.md#ale-47-counter-measure-dispensing-system-cdms-programming)                                           |
+|   9.    | [CMDS](../mdl/mission_data_loader.md#ale-47-counter-measure-dispensing-system-cdms-programming)                                           |
 |   10.   | [Tactical Imaging Set](../mdl/mission_data_loader.md#tactical-imaging-system)                                                             |

--- a/src/f14bu/systems/nav_com/cdnu/control_display_navigation_unit.md
+++ b/src/f14bu/systems/nav_com/cdnu/control_display_navigation_unit.md
@@ -520,7 +520,7 @@ STEP 3: Vertical scroll until MDL START page
 The Mission Data Loader (MDL) provides bulk storage of mission essential data.
 The Data Transfer Module (DTM), can be loaded in the Mission Editor with up to
 12 flight plans, Pre-Planned Missions for JDAM employment and countermeasure
-profiles for the ALE-47 CDMS.
+profiles for the ALE-47 CMDS.
 
 The MDL Start page is accessed by scrolling up from the EGI Start 1/2 page or
 down from the EGI Start 2/2 page. Display line 3 contains the MDL cartridge


### PR DESCRIPTION
- Elaborate more on the DCS DTC implementation with a direct link to the MDL section.
- Fix link to JDAM employment section in ME page (extra /).
- Fix numerous misspellings of "CMDS" from "CDMS".