### PR TITLE
Add note about point track with LANTIRN to LANTIRN pages

### DIFF
--- a/src/f14ab/systems/lantirn/modes.md
+++ b/src/f14ab/systems/lantirn/modes.md
@@ -15,6 +15,12 @@ in itself only allows for angle tracking which gives imprecise ranging using own
 aircraft position and pod line of sight to calculate target position. It does
 however allow the system to track moving targets.
 
+> 💡 Point Track with the LANTIRN can only be engaged on object that appear
+> white on a dark background no matter the polarity mode (WHOT or BHOT). In DCS,
+> due to limitations in simulation, Point Track can only be initiated in WHOT
+> mode. Once Point Track is successfully engaged in WHOT, it is possible to
+> change the polarity to BHOT.
+
 The last tracking mode has the sensor slewed to a stored location/direction,
 called a Q. The directional Qs do not allow for guidance to a location while the
 location Qs do.

--- a/src/f14bu/systems/lantirn/lantirn_targeting_system.md
+++ b/src/f14bu/systems/lantirn/lantirn_targeting_system.md
@@ -70,6 +70,12 @@ is too close and has too little thermal detail to point track), the LTS defaults
 to area track mode, except A-A mode in which case the LTS transitions to
 computed rates mode.
 
+> 💡 Point Track with the LANTIRN can only be engaged on object that appear
+> white on a dark background no matter the polarity mode (WHOT or BHOT). In DCS,
+> due to limitations in simulation, Point Track can only be initiated in WHOT
+> mode. Once Point Track is successfully engaged in WHOT, it is possible to
+> change the polarity to BHOT.
+
 ## Q (Cue) Modes
 
 - Q Waypoint: With Q waypoint any of 20 LTS designated waypoints can be toggled


### PR DESCRIPTION
Important to add since it is a very surprising limitation of the LANTIRN and does trip people up from time to time.

Added to both A/B and B(U) LANTIRN pages.